### PR TITLE
removed line with pkg_resources in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,6 @@ nvidia-nvtx-cu12==12.1.105
 opencv-python==4.9.0.80
 packaging==24.0
 pillow==10.3.0
-pkg_resources==0.0.0
 psutil==5.9.8
 PyYAML==6.0.1
 regex==2024.5.15


### PR DESCRIPTION
The following error occurs during the installation of dependencies from the requirements.txt file:
```bash
ERROR: Could not find a version that satisfies the requirement pkg_resources==0.0.0 (from versions: none)
ERROR: No matching distribution found for pkg_resources==0.0.0
```
Since the pkg_resources module is part of the setuptools package and does not need to be explicitly listed in the requirements.txt file, the line with _pkg_resources==0.0.0_ can be removed.